### PR TITLE
feat: #WB-3141, fetch module version from gradle.properties to construct ent-core.json

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=fr.wseduc
 archivesBaseName=springboard-plugin
-version=2.7.8
+version=2.7.9

--- a/src/main/groovy/fr/wseduc/gradle/springboard/FileUtils.groovy
+++ b/src/main/groovy/fr/wseduc/gradle/springboard/FileUtils.groovy
@@ -5,7 +5,10 @@ import org.gradle.api.Project
 
 class FileUtils {
 
-	static def createFile(String propertiesFile, String templateFileName, String outputFileName) {
+	static def createFile(String propertiesFile, 
+						  String gradleFile,
+						  String templateFileName,
+						  String outputFileName) {
 		def props = new Properties()
 		def file = new File(propertiesFile)
 		def rootDirectory = file.getParentFile()
@@ -18,8 +21,12 @@ class FileUtils {
 				bindings[prop] = props.getProperty(prop)
 			}
 		}
+		def gradleProps = new Properties()
+		gradleProps.load(new FileInputStream(gradleFile))
+		removeUselessGradleProps(gradleProps);
 		def defaultProps = new Properties()
 		defaultProps.load(new FileInputStream(new File(rootDirectory, "default.properties")))
+		defaultProps.putAll(gradleProps)
 		defaultProps.propertyNames().each { prop ->
 			if (!bindings.containsKey(prop)) {
 				bindings[prop] = defaultProps.getProperty(prop)
@@ -36,6 +43,16 @@ class FileUtils {
 		fileWriter.close()
 	}
 
+	/**
+	* Removes from the specified props the properties that are not
+	* useful for the generation of the entcore.json
+	*/
+	static def removeUselessGradleProps(Properties props) {
+		props.remove("modowner");
+		props.remove("modname");
+		props.remove("version");
+		props.remove("produceJar");
+	}
 
 	static def copy(InputStream is, File output) {
 		int read;

--- a/src/main/groovy/fr/wseduc/gradle/springboard/SpringboardPlugin.groovy
+++ b/src/main/groovy/fr/wseduc/gradle/springboard/SpringboardPlugin.groovy
@@ -11,7 +11,7 @@ class SpringboardPlugin implements Plugin<Project> {
 	void apply(Project project) {
 		project.task("generateConf") << {
 			def rootDir = project.getRootDir().getAbsolutePath()
-			FileUtils.createFile("${rootDir}/conf.properties", "${rootDir}/ent-core.json.template", "${rootDir}/ent-core.json")
+			FileUtils.createFile("${rootDir}/conf.properties", "${rootDir}/gradle.properties", "${rootDir}/ent-core.json.template", "${rootDir}/ent-core.json")
 		}
 
 		project.task("extractDeployments") << {


### PR DESCRIPTION
# Description

Récupération des valeurs du gradle.properties de la recette afin de pouvoir réutiliser les valeurs dans la génération du fichier ent-core.json au moment de l'exécution de la taĉhe generateConf.
Cela permet de nous passer de recopier à la main la valeur des versions dans le fichier conf.template de chaque module et de réutiliser à la placer le nom de la propriété contenant la version.

Exemple pour le blog :
Avant -> `"name": "org.entcore~blog~~4.0-b2school-SNAPSHOT",`
Après -> `"name": "org.entcore~blog~${blogVersion}",`